### PR TITLE
Fix Transit Gateway mode to use availability_zone_mapping

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,16 @@ output "network_firewall_policy_arn" {
 }
 
 output "az_subnet_endpoint_stats" {
-  description = "List of objects with each object having three items: AZ, subnet ID, firewall VPC endpoint ID"
+  description = "List of objects with each object having three items: AZ, subnet ID, firewall VPC endpoint ID. Only applicable in VPC mode"
   value       = local.az_subnet_endpoint_stats
+}
+
+output "transit_gateway_attachment_id" {
+  description = "The unique identifier of the transit gateway attachment. Only applicable in Transit Gateway mode"
+  value       = local.enabled && local.is_tgw_mode ? try(one(aws_networkfirewall_firewall.default[*].firewall_status[0].transit_gateway_attachment_sync_states[0].attachment_id), null) : null
+}
+
+output "transit_gateway_owner_account_id" {
+  description = "The AWS account ID that owns the transit gateway. Only applicable in Transit Gateway mode"
+  value       = local.enabled && local.is_tgw_mode ? try(one(aws_networkfirewall_firewall.default[*].transit_gateway_owner_account_id), null) : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,8 @@ variable "network_firewall_policy_name" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "List of subnet IDs for firewall endpoints"
+  description = "List of subnet IDs for firewall endpoints. Required when using 'vpc_id', not used when using 'transit_gateway_id'"
+  default     = []
 }
 
 variable "vpc_id" {
@@ -29,8 +30,14 @@ variable "vpc_id" {
 
 variable "transit_gateway_id" {
   type        = string
-  description = "The unique identifier of the transit gateway to attach to this firewall. You can provide either a transit gateway from your account or one that has been shared with you through AWS Resource Access Manager. Either 'vpc_id' or 'transit_gateway_id' must be provided, but not both"
+  description = "The unique identifier of the Transit Gateway to attach to this firewall. You can provide either a Transit Gateway from your account or one that has been shared with you through AWS Resource Access Manager. Either 'vpc_id' or 'transit_gateway_id' must be provided, but not both"
   default     = null
+}
+
+variable "availability_zone_ids" {
+  type        = list(string)
+  description = "List of Availability Zone IDs where firewall endpoints will be created for a transit gateway-attached firewall. Required when using 'transit_gateway_id', not used when using 'vpc_id'"
+  default     = []
 }
 
 variable "policy_stateful_engine_options_rule_order" {


### PR DESCRIPTION
## what

- Fix Transit Gateway deployment mode to properly use `availability_zone_mapping` instead of `subnet_mapping`
- Add `availability_zone_ids` variable for specifying Availability Zone IDs in TGW mode
- Make `subnet_ids` optional (default = []) since it's not used in TGW mode
- Add deployment mode detection logic to determine VPC vs TGW mode
- Make `subnet_mapping` block conditional (only populated in VPC mode)
- Add `availability_zone_mapping` block for TGW mode (only populated when using Transit Gateway)
- Add precondition validations to ensure correct parameters are provided for each mode
- Update `az_subnet_endpoint_stats` output to only work in VPC mode (not applicable to TGW)
- Add `transit_gateway_attachment_id` output for TGW mode
- Add `transit_gateway_owner_account_id` output for TGW mode

## why

- The initial TGW implementation in PR #32 incorrectly used `subnet_mapping` for both VPC and TGW modes
- According to AWS Terraform provider documentation, Transit Gateway attached firewalls require `availability_zone_mapping` with Availability Zone IDs, not `subnet_mapping` with subnet IDs
- In TGW mode, the firewall is attached directly to the Transit Gateway and uses Availability Zones instead of VPC subnets
- This is a critical fix to ensure TGW mode works correctly according to the AWS provider specification
- Without this fix, Transit Gateway mode would fail because `subnet_mapping` is only valid for VPC-attached firewalls

## references

- Terraform AWS provider docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall#transit-gateway-attached-firewall
- AWS provider PR that added TGW support: https://github.com/hashicorp/terraform-provider-aws/pull/43430
- AWS announcement: https://aws.amazon.com/about-aws/whats-new/2025/06/aws-network-firewall-transit-gateway-native-integration/
- AWS documentation: https://docs.aws.amazon.com/network-firewall/latest/developerguide/tgw-firewall.html